### PR TITLE
Undo statefulsets

### DIFF
--- a/nzbget/Chart.yaml
+++ b/nzbget/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: amd64-v21.0-r2296-ls5
+appVersion: amd64-v21.0-r2302-ls8
 description: NZBGet is a Usenet downloader client
 name: nzbget
-version: 1.1.2
+version: 2.0.2
 keywords:
   - nzbget
   - usenet

--- a/nzbget/README.md
+++ b/nzbget/README.md
@@ -39,8 +39,9 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | Parameter                  | Description                         | Default                                                 |
 |----------------------------|-------------------------------------|---------------------------------------------------------|
 | `image.repository`         | Image repository | `linuxserver/nzbget` |
-| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/linuxserver/nzbget/tags/).| `147`|
+| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/linuxserver/nzbget/tags/).| `amd64-v21.0-r2302-ls8 `|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
+| `strategyType`             | Specifies the strategy used to replace old Pods by new ones | `Recreate` |
 | `timezone`                 | Timezone the nzbget instance should run as, e.g. 'America/New_York' | `UTC` |
 | `puid`                     | process userID the nzbget instance should run as | `1001` |
 | `pgid`                     | process groupID the nzbget instance should run as | `1001` |

--- a/nzbget/templates/config-pvc.yaml
+++ b/nzbget/templates/config-pvc.yaml
@@ -1,0 +1,25 @@
+
+{{- if and .Values.persistence.config.enabled (not .Values.persistence.config.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "nzbget.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: {{ include "nzbget.name" . }}
+    helm.sh/chart: {{ include "nzbget.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.config.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.config.size | quote }}
+{{- if .Values.persistence.config.storageClass }}
+{{- if (eq "-" .Values.persistence.config.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.config.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/nzbget/templates/deployment.yaml
+++ b/nzbget/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "nzbget.fullname" . }}
   labels:
@@ -8,8 +8,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  podManagementPolicy: "Parallel"
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
+  strategy:
+    type: {{ .Values.strategyType }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "nzbget.name" . }}
@@ -52,6 +53,13 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:
+      - name: config
+      {{- if .Values.persistence.config.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ if .Values.persistence.config.existingClaim }}{{ .Values.persistence.config.existingClaim }}{{- else }}{{ template "nzbget.fullname" . }}-config{{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{ end }}
       - name: downloads
       {{- if .Values.persistence.downloads.enabled }}
         persistentVolumeClaim:
@@ -59,38 +67,6 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-{{- if and .Values.persistence.config.enabled .Values.persistence.config.existingClaim }}
-      - name: config
-      {{- if .Values.persistence.config.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.persistence.config.existingClaim }}
-      {{- else }}
-        emptyDir: {}
-      {{- end }}
-{{- else if not .Values.persistence.config.enabled }}
-      - name: config
-        emptyDir: {}
-{{- else if and .Values.persistence.config.enabled (not .Values.persistence.config.existingClaim) }}
-  volumeClaimTemplates:
-  - metadata:
-      name: config
-      labels:
-        app.kubernetes.io/name: {{ include "nzbget.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    spec:
-      accessModes: 
-        - {{ .Values.persistence.config.accessMode | quote }}
-      resources:
-        requests:
-          storage: {{ .Values.persistence.config.size | quote }}
-      {{- if .Values.persistence.config.storageClass }}
-      {{- if (eq "-" .Values.persistence.config.storageClass) }}
-        storageClassName: ""
-      {{- else }}
-        storageClassName: "{{ .Values.persistence.config.storageClass }}"
-      {{- end }}
-      {{- end }}
-{{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/nzbget/values.yaml
+++ b/nzbget/values.yaml
@@ -2,12 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
 image:
   repository: linuxserver/nzbget
-  tag: amd64-v21.0-r2296-ls5
+  tag: amd64-v21.0-r2302-ls8 
   pullPolicy: IfNotPresent
+
+# upgrade strategy type (e.g. Recreate or RollingUpdate)
+strategyType: Recreate
 
 nameOverride: ""
 fullnameOverride: ""

--- a/radarr/Chart.yaml
+++ b/radarr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: amd64-0.2.0.1318-ls6
+appVersion: amd64-v0.2.0.1293-ls9
 description: Radarr is a movie downloading client
 name: radarr
-version: 1.1.1
+version: 2.0.2
 keywords:
   - radarr
   - usenet

--- a/radarr/README.md
+++ b/radarr/README.md
@@ -34,8 +34,9 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | Parameter                  | Description                         | Default                                                 |
 |----------------------------|-------------------------------------|---------------------------------------------------------|
 | `image.repository`         | Image repository | `linuxserver/radarr` |
-| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/linuxserver/radarr/tags/).| `137`|
+| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/linuxserver/radarr/tags/).| `amd64-v0.2.0.1293-ls9`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
+| `strategyType`             | Specifies the strategy used to replace old Pods by new ones | `Recreate` |
 | `timezone`                 | Timezone the radarr instance should run as, e.g. 'America/New_York' | `UTC` |
 | `puid`                     | process userID the radarr instance should run as | `1001` |
 | `pgid`                     | process groupID the radarr instance should run as | `1001` |

--- a/radarr/templates/config-pvc.yaml
+++ b/radarr/templates/config-pvc.yaml
@@ -1,0 +1,25 @@
+
+{{- if and .Values.persistence.config.enabled (not .Values.persistence.config.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "radarr.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: {{ include "radarr.name" . }}
+    helm.sh/chart: {{ include "radarr.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.config.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.config.size | quote }}
+{{- if .Values.persistence.config.storageClass }}
+{{- if (eq "-" .Values.persistence.config.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.config.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/radarr/templates/deployment.yaml
+++ b/radarr/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "radarr.fullname" . }}
   labels:
@@ -8,8 +8,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  podManagementPolicy: "Parallel"
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
+  strategy:
+    type: {{ .Values.strategyType }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "radarr.name" . }}
@@ -62,6 +63,13 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:
+      - name: config
+      {{- if .Values.persistence.config.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ if .Values.persistence.config.existingClaim }}{{ .Values.persistence.config.existingClaim }}{{- else }}{{ template "radarr.fullname" . }}-config{{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
       - name: downloads
       {{- if .Values.persistence.downloads.enabled }}
         persistentVolumeClaim:
@@ -81,38 +89,6 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .existingClaim }}
       {{- end }}
-{{- if and .Values.persistence.config.enabled .Values.persistence.config.existingClaim }}
-      - name: config
-      {{- if .Values.persistence.config.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.persistence.config.existingClaim }}
-      {{- else }}
-        emptyDir: {}
-      {{- end }}
-{{- else if not .Values.persistence.config.enabled }}
-      - name: config
-        emptyDir: {}
-{{- else if and .Values.persistence.config.enabled (not .Values.persistence.config.existingClaim) }}
-  volumeClaimTemplates:
-  - metadata:
-      name: config
-      labels:
-        app.kubernetes.io/name: {{ include "radarr.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    spec:
-      accessModes: 
-        - {{ .Values.persistence.config.accessMode | quote }}
-      resources:
-        requests:
-          storage: {{ .Values.persistence.config.size | quote }}
-      {{- if .Values.persistence.config.storageClass }}
-      {{- if (eq "-" .Values.persistence.config.storageClass) }}
-        storageClassName: ""
-      {{- else }}
-        storageClassName: "{{ .Values.persistence.config.storageClass }}"
-      {{- end }}
-      {{- end }}
-{{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/radarr/values.yaml
+++ b/radarr/values.yaml
@@ -2,12 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
 image:
   repository: linuxserver/radarr
-  tag: amd64-0.2.0.1318-ls6
+  tag: amd64-v0.2.0.1293-ls9
   pullPolicy: IfNotPresent
+
+# upgrade strategy type (e.g. Recreate or RollingUpdate)
+strategyType: Recreate
 
 nameOverride: ""
 fullnameOverride: ""

--- a/rtorrent-flood/Chart.yaml
+++ b/rtorrent-flood/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.9.7-0.13.7
 description: flood-rtorrent
 name: rtorrent-flood
-version: 1.1.1
+version: 2.0.7
 keywords:
   - rtorrent
   - flood

--- a/rtorrent-flood/templates/config-pvc.yaml
+++ b/rtorrent-flood/templates/config-pvc.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.persistence.config.enabled (not .Values.persistence.config.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "rtorrent-flood.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: {{ include "rtorrent-flood.name" . }}
+    helm.sh/chart: {{ include "rtorrent-flood.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.config.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.config.size | quote }}
+{{- if .Values.persistence.config.storageClass }}
+{{- if (eq "-" .Values.persistence.config.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.config.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/rtorrent-flood/templates/deployment.yaml
+++ b/rtorrent-flood/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ template "rtorrent-flood.fullname" . }}
   labels:
@@ -8,8 +8,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  podManagementPolicy: "Parallel"
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
+  strategy:
+    type: {{ .Values.strategyType }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "rtorrent-flood.name" . }}
@@ -34,13 +35,15 @@ spec:
           livenessProbe:
             httpGet:
               port: http
-              scheme: HTTP
-              initialDelaySeconds: 30
+            initialDelaySeconds: 30
+            failureThreshold: 5
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
               port: http
-              scheme: HTTP
-              initialDelaySeconds: 15
+            initialDelaySeconds: 30
+            failureThreshold: 5
+            timeoutSeconds: 10
           tty: true
           env:
             - name: TZ
@@ -62,6 +65,13 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:
+      - name: flood-db
+      {{- if .Values.persistence.config.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ if .Values.persistence.config.existingClaim }}{{ .Values.persistence.config.existingClaim }}{{- else }}{{ template "rtorrent-flood.fullname" . }}-config{{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{ end }}
       - name: data
       {{- if .Values.persistence.data.enabled }}
         persistentVolumeClaim:
@@ -69,38 +79,6 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-{{- if and .Values.persistence.config.enabled .Values.persistence.config.existingClaim }}
-      - name: flood-db
-      {{- if .Values.persistence.config.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.persistence.config.existingClaim }}
-      {{- else }}
-        emptyDir: {}
-      {{- end }}
-{{- else if not .Values.persistence.config.enabled }}
-      - name: flood-db
-        emptyDir: {}
-{{- else if and .Values.persistence.config.enabled (not .Values.persistence.config.existingClaim) }}
-  volumeClaimTemplates:
-  - metadata:
-      name: flood-db
-      labels:
-        app.kubernetes.io/name: {{ include "rtorrent-flood.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    spec:
-      accessModes: 
-        - {{ .Values.persistence.config.accessMode | quote }}
-      resources:
-        requests:
-          storage: {{ .Values.persistence.config.size | quote }}
-      {{- if .Values.persistence.config.storageClass }}
-      {{- if (eq "-" .Values.persistence.config.storageClass) }}
-        storageClassName: ""
-      {{- else }}
-        storageClassName: "{{ .Values.persistence.config.storageClass }}"
-      {{- end }}
-      {{- end }}
-{{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/rtorrent-flood/values.yaml
+++ b/rtorrent-flood/values.yaml
@@ -2,12 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
 image:
   repository: wonderfall/rtorrent-flood
   tag: 0.9.7-0.13.7
   pullPolicy: IfNotPresent
+
+# upgrade strategy type (e.g. Recreate or RollingUpdate)
+strategyType: Recreate
 
 nameOverride: ""
 fullnameOverride: ""

--- a/sonarr/Chart.yaml
+++ b/sonarr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: amd64-2.0.0.5318-ls31
+appVersion: amd64-3.0.1.418-ls45
 description: Sonarr is a television show downloading client
 name: sonarr
-version: 1.1.2
+version: 2.0.2
 keywords:
   - sonarr
   - usenet

--- a/sonarr/README.md
+++ b/sonarr/README.md
@@ -34,8 +34,9 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | Parameter                  | Description                         | Default                                                 |
 |----------------------------|-------------------------------------|---------------------------------------------------------|
 | `image.repository`         | Image repository | `linuxserver/sonarr` |
-| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/linuxserver/sonarr/tags/).| `162`|
+| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/linuxserver/sonarr/tags/).| `amd64-3.0.1.418-ls45`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
+| `strategyType`             | Specifies the strategy used to replace old Pods by new ones | `Recreate` |
 | `timezone`                 | Timezone the sonarr instance should run as, e.g. 'America/New_York' | `UTC` |
 | `puid`                     | process userID the sonarr instance should run as | `1001` |
 | `pgid`                     | process groupID the sonarr instance should run as | `1001` |

--- a/sonarr/templates/config-pvc.yaml
+++ b/sonarr/templates/config-pvc.yaml
@@ -1,0 +1,25 @@
+
+{{- if and .Values.persistence.config.enabled (not .Values.persistence.config.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "sonarr.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: {{ include "sonarr.name" . }}
+    helm.sh/chart: {{ include "sonarr.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.config.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.config.size | quote }}
+{{- if .Values.persistence.config.storageClass }}
+{{- if (eq "-" .Values.persistence.config.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.config.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/sonarr/templates/deployment.yaml
+++ b/sonarr/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "sonarr.fullname" . }}
   labels:
@@ -8,8 +8,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  podManagementPolicy: "Parallel"
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
+  strategy:
+    type: {{ .Values.strategyType }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "sonarr.name" . }}
@@ -64,6 +65,13 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:
+      - name: config
+      {{- if .Values.persistence.config.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ if .Values.persistence.config.existingClaim }}{{ .Values.persistence.config.existingClaim }}{{- else }}{{ template "sonarr.fullname" . }}-config{{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
       - name: downloads
       {{- if .Values.persistence.downloads.enabled }}
         persistentVolumeClaim:
@@ -83,38 +91,6 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .existingClaim }}
       {{- end }}
-{{- if and .Values.persistence.config.enabled .Values.persistence.config.existingClaim }}
-      - name: config
-      {{- if .Values.persistence.config.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.persistence.config.existingClaim }}
-      {{- else }}
-        emptyDir: {}
-      {{- end }}
-{{- else if not .Values.persistence.config.enabled }}
-      - name: config
-        emptyDir: {}
-{{- else if and .Values.persistence.config.enabled (not .Values.persistence.config.existingClaim) }}
-  volumeClaimTemplates:
-  - metadata:
-      name: config
-      labels:
-        app.kubernetes.io/name: {{ include "sonarr.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-    spec:
-      accessModes: 
-        - {{ .Values.persistence.config.accessMode | quote }}
-      resources:
-        requests:
-          storage: {{ .Values.persistence.config.size | quote }}
-      {{- if .Values.persistence.config.storageClass }}
-      {{- if (eq "-" .Values.persistence.config.storageClass) }}
-        storageClassName: ""
-      {{- else }}
-        storageClassName: "{{ .Values.persistence.config.storageClass }}"
-      {{- end }}
-      {{- end }}
-{{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/sonarr/values.yaml
+++ b/sonarr/values.yaml
@@ -2,12 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
 image:
   repository: linuxserver/sonarr
-  tag: amd64-2.0.0.5318-ls31
+  tag: amd64-3.0.1.418-ls45
   pullPolicy: IfNotPresent
+
+# upgrade strategy type (e.g. Recreate or RollingUpdate)
+strategyType: Recreate
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Instead of using statefulset for some of the charts with persistent storage, using an update strategy of Recreate instead of RollingUpdate