### PR TITLE
Add name to repo add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@
 ## Installation
 
 ```console
-helm repo add https://billimek.com/billimek-charts/
+helm repo add billimek https://billimek.com/billimek-charts/
 helm search billimek
 ```


### PR DESCRIPTION
`repo add` requires a name in addition to the URL, just adding it to your install command to match your search command expectation.

```
$ helm repo add https://billimek.com/billimek-charts/
Error: This command needs 2 arguments: name for the chart repository, the url of the chart repository
```