### PR TITLE
implement revisionHistoryLimit: 3

### DIFF
--- a/charts/comcast/Chart.yaml
+++ b/charts/comcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: comcast
-version: 2.0.0
+version: 2.0.1
 appVersion: 1.0.0
 description: periodic comcast data usage checks and save the results to InfluxDB
 keywords:

--- a/charts/comcast/templates/deployment.yaml
+++ b/charts/comcast/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
       app: {{ template "comcast.name" . }}
       release: {{ .Release.Name }}
   replicas: {{ default 1 .Values.replicas }}
+  revisionHistoryLimit: 3
   template:
     metadata:
       labels:

--- a/charts/digitalocean-dyndns/Chart.yaml
+++ b/charts/digitalocean-dyndns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: Dynamic DNS using DigitalOcean's DNS Services
 name: digitalocean-dyndns
-version: 1.0.0
+version: 1.0.1
 keywords:
 - digitalocean
 - dynamicdns

--- a/charts/digitalocean-dyndns/templates/deployment.yaml
+++ b/charts/digitalocean-dyndns/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app: {{ template "digitalocean-dyndns.name" . }}

--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.0"
 description: Realtime object detection on RTSP cameras with the Google Coral
 name: frigate
-version: 2.1.0
+version: 2.1.1
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
 {{ include "frigate.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 3
   strategy:
     type: {{ .Values.strategyType }}
   selector:

--- a/charts/jackett/Chart.yaml
+++ b/charts/jackett/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.12.1582-ls39
 description: API Support for your favorite torrent trackers
 name: jackett
-version: 2.0.1
+version: 2.0.2
 keywords:
   - jackett
   - torrent

--- a/charts/jackett/templates/deployment.yaml
+++ b/charts/jackett/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: 1
+  revisionHistoryLimit: 3
   strategy:
     type: {{ .Values.strategyType }}
   selector:

--- a/charts/modem-stats/Chart.yaml
+++ b/charts/modem-stats/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: modem-stats
-version: 2.0.0
+version: 2.0.1
 appVersion: 1.0.0
 description: periodic cable modem data collection and save the results to InfluxDB
 keywords:

--- a/charts/modem-stats/templates/deployment.yaml
+++ b/charts/modem-stats/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
       app: {{ template "modem-stats.name" . }}
       release: {{ .Release.Name }}
   replicas: {{ default 1 .Values.replicas }}
+  revisionHistoryLimit: 3
   template:
     metadata:
       labels:

--- a/charts/nzbget/Chart.yaml
+++ b/charts/nzbget/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v21.0-ls14
 description: NZBGet is a Usenet downloader client
 name: nzbget
-version: 3.1.1
+version: 3.1.2
 keywords:
   - nzbget
   - usenet

--- a/charts/nzbget/templates/deployment.yaml
+++ b/charts/nzbget/templates/deployment.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: 1
+  revisionHistoryLimit: 3
   strategy:
     type: {{ .Values.strategyType }}
   selector:

--- a/charts/nzbhydra2/Chart.yaml
+++ b/charts/nzbhydra2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.11.2-ls53
 description: Usenet meta search
 name: nzbhydra2
-version: 2.0.2
+version: 2.0.3
 keywords:
   - nzbhydra2
   - usenet

--- a/charts/nzbhydra2/templates/deployment.yaml
+++ b/charts/nzbhydra2/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: 1
+  revisionHistoryLimit: 3
   strategy:
     type: {{ .Values.strategyType }}
   selector:

--- a/charts/ombi/Chart.yaml
+++ b/charts/ombi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 3.0.4958-ls73
 description: Want a Movie or TV Show on Plex or Emby? Use Ombi!
 name: ombi
-version: 2.0.2
+version: 2.0.3
 keywords:
   - ombi
   - plex

--- a/charts/ombi/templates/deployment.yaml
+++ b/charts/ombi/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: 1
+  revisionHistoryLimit: 3
   strategy:
     type: {{ .Values.strategyType }}
   selector:

--- a/charts/qbittorrent/Chart.yaml
+++ b/charts/qbittorrent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 4.2.1
 description: qBittorrent is a cross-platform free and open-source BitTorrent client
 name: qbittorrent
-version: 3.0.0
+version: 3.0.1
 keywords:
   - qbittorrent
   - torrrent

--- a/charts/qbittorrent/templates/deployment.yaml
+++ b/charts/qbittorrent/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: 1
+  revisionHistoryLimit: 3
   strategy:
     type: {{ .Values.strategyType }}
   selector:

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: amd64-v0.2.0.1344-ls17
 description: Radarr is a movie downloading client
 name: radarr
-version: 3.0.1
+version: 3.0.2
 keywords:
   - radarr
   - usenet

--- a/charts/radarr/templates/deployment.yaml
+++ b/charts/radarr/templates/deployment.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: 1
+  revisionHistoryLimit: 3
   strategy:
     type: {{ .Values.strategyType }}
   selector:

--- a/charts/rtorrent-flood/Chart.yaml
+++ b/charts/rtorrent-flood/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: rtorrent and flood co-located in the same deployment
 name: rtorrent-flood
-version: 4.0.0
+version: 4.0.1
 keywords:
   - rtorrent
   - flood

--- a/charts/rtorrent-flood/templates/deployment.yaml
+++ b/charts/rtorrent-flood/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: 1
+  revisionHistoryLimit: 3
   strategy:
     type: {{ .Values.strategyType }}
   selector:

--- a/charts/ser2sock/Chart.yaml
+++ b/charts/ser2sock/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: Serial to Socket Redirector
 name: ser2sock
-version: 1.0.0
+version: 1.0.1
 keywords:
   - ser2sock
 home: https://github.com/billimek/billimek-charts/tree/master/charts/ser2sock

--- a/charts/ser2sock/templates/deployment.yaml
+++ b/charts/ser2sock/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
 {{ include "ser2sock.labels" . | indent 4 }}
 spec:
   replicas: 1
+  revisionHistoryLimit: 3
   strategy:
     type: {{ .Values.strategyType }}
   selector:

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: amd64-2.0.0.5321-ls62
 description: Sonarr is a television show downloading client
 name: sonarr
-version: 3.0.1
+version: 3.0.2
 keywords:
   - sonarr
   - usenet

--- a/charts/sonarr/templates/deployment.yaml
+++ b/charts/sonarr/templates/deployment.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: 1
+  revisionHistoryLimit: 3
   strategy:
     type: {{ .Values.strategyType }}
   selector:

--- a/charts/speedtest/Chart.yaml
+++ b/charts/speedtest/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: speedtest
-version: 2.0.0
+version: 2.0.1
 appVersion: 1.0.0
 description: periodic speedtest and save the results to InfluxDB
 keywords:

--- a/charts/speedtest/templates/deployment.yaml
+++ b/charts/speedtest/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
       app: {{ template "speedtest.name" . }}
       release: {{ .Release.Name }}
   replicas: {{ default 1 .Values.replicas }}
+  revisionHistoryLimit: 3
   template:
     metadata:
       labels:

--- a/charts/tautulli/Chart.yaml
+++ b/charts/tautulli/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.1.42-ls34
 description: A Python based monitoring and tracking tool for Plex Media Server.
 name: tautulli
-version: 2.0.1
+version: 2.0.2
 keywords:
   - tautulli
   - plex

--- a/charts/tautulli/templates/deployment.yaml
+++ b/charts/tautulli/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: 1
+  revisionHistoryLimit: 3
   strategy:
     type: {{ .Values.strategyType }}
   selector:

--- a/charts/teslamate/Chart.yaml
+++ b/charts/teslamate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.16.0"
 description: A self-hosted data logger for your Tesla 🚘
 name: teslamate
-version: 2.0.2
+version: 2.0.3
 keywords:
   - teslamate
   - tesla

--- a/charts/teslamate/templates/deployment.yaml
+++ b/charts/teslamate/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "teslamate.name" . }}

--- a/charts/uptimerobot/Chart.yaml
+++ b/charts/uptimerobot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: uptimerobot
-version: 2.0.0
+version: 2.0.1
 appVersion: 1.1.0
 description: A tool to get statistics from Uptime Robot and log it into InfluxDB
 keywords:

--- a/charts/uptimerobot/templates/deployment.yaml
+++ b/charts/uptimerobot/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
       app: {{ template "uptimerobot.name" . }}
       release: {{ .Release.Name }}
   replicas: {{ default 1 .Values.replicas }}
+  revisionHistoryLimit: 3
   template:
     metadata:
       labels:

--- a/charts/zwave2mqtt/Chart.yaml
+++ b/charts/zwave2mqtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.2.0"
 description: Fully configurable Zwave to MQTT gateway and Control Panel using NodeJS and Vue
 name: zwave2mqtt
-version: 1.0.2
+version: 1.0.3
 keywords:
   - zwave
   - mqtt

--- a/charts/zwave2mqtt/templates/deployment.yaml
+++ b/charts/zwave2mqtt/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
 {{ include "zwave2mqtt.labels" . | indent 4 }}
 spec:
   replicas: 1
+  revisionHistoryLimit: 3
   strategy:
     type: {{ .Values.strategyType }}
   selector:


### PR DESCRIPTION
#### Special notes for your reviewer:

Kubernetes default `revisionHistoryLimit` is 10, I have changed this:

Added `revisionHistoryLimit: 3` for all charts and deployments

Closes: https://github.com/billimek/billimek-charts/issues/151