### PR TITLE
Add skipuninstall value to avoid deleting pvc upon helm uninstall

### DIFF
--- a/charts/jackett/Chart.yaml
+++ b/charts/jackett/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.13.446-ls55
 description: API Support for your favorite torrent trackers
 name: jackett
-version: 2.2.1
+version: 2.3.0
 keywords:
   - jackett
   - torrent

--- a/charts/jackett/README.md
+++ b/charts/jackett/README.md
@@ -65,12 +65,14 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `persistence.config.subPath`  | Mount a sub directory of the persistent volume if set | `""` |
 | `persistence.config.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.config.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.config.skipuninstall`  | Do not delete the pvc upon helm uninstall | `false` |
 | `persistence.torrentblackhole.enabled`      | Use persistent volume to store torrent files | `false` |
 | `persistence.torrentblackhole.size`         | Size of persistent volume claim | `1Gi` |
 | `persistence.torrentblackhole.existingClaim`| Use an existing PVC to persist data | `nil` |
 | `persistence.torrentblackhole.subPath`  | Mount a sub directory of the persistent volume if set | `""` |
 | `persistence.torrentblackhole.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.torrentblackhole.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.torrentblackhole.skipuninstall`  | Do not delete the pvc upon helm uninstall | `false` |
 | `persistence.extraExistingClaimMounts`  | Optionally add multiple existing claims | `[]` |
 | `resources`                | CPU/Memory resource requests/limits | `{}` |
 | `nodeSelector`             | Node labels for pod assignment | `{}` |
@@ -92,5 +94,12 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 ```console
 helm install --name my-release -f values.yaml billimek/jackett
 ```
+
+---
+**NOTE**
+
+If you get `Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: ...` it may be because you uninstalled the chart with `skipuninstall` enabled, you need to manually delete the pvc or use `existingClaim`.
+
+---
 
 Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/jackett/values.yaml) file. It has several commented out suggested values.

--- a/charts/jackett/templates/config-pvc.yaml
+++ b/charts/jackett/templates/config-pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "jackett.fullname" . }}-config
+  {{- if .Values.persistence.config.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "jackett.name" . }}
     helm.sh/chart: {{ include "jackett.chart" . }}

--- a/charts/jackett/templates/torrent-blackhole-pvc.yaml
+++ b/charts/jackett/templates/torrent-blackhole-pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "jackett.fullname" . }}-torrentblackhole
+  {{- if .Values.persistence.torrentblackhole.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "jackett.name" . }}
     helm.sh/chart: {{ include "jackett.chart" . }}

--- a/charts/jackett/values.yaml
+++ b/charts/jackett/values.yaml
@@ -86,6 +86,8 @@ persistence:
     ## This is especially handy for volume plugins that don't natively support sub mounting (like glusterfs).
     ##
     subPath: ""
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
   torrentblackhole:
     enabled: false
     ## Jackett torrentblackhole directory volume configuration
@@ -103,6 +105,8 @@ persistence:
     # subPath: some-subpath
     accessMode: ReadWriteOnce
     size: 1Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/nzbget/Chart.yaml
+++ b/charts/nzbget/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v21.0-ls14
 description: NZBGet is a Usenet downloader client
 name: nzbget
-version: 3.1.2
+version: 3.2.0
 keywords:
   - nzbget
   - usenet

--- a/charts/nzbget/README.md
+++ b/charts/nzbget/README.md
@@ -68,11 +68,13 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `persistence.config.existingClaim`| Use an existing PVC to persist data | `nil` |
 | `persistence.config.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.config.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.config.skipuninstall`  | Do not delete the pvc upon helm uninstall | `false` |
 | `persistence.downloads.enabled`      | Use persistent volume to store configuration data | `true` |
 | `persistence.downloads.size`         | Size of persistent volume claim | `10Gi` |
 | `persistence.downloads.existingClaim`| Use an existing PVC to persist data | `nil` |
 | `persistence.downloads.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.downloads.accessMode`   | Persistence access mode | `ReadWriteOnce` |
+| `persistence.downloads.skipuninstall`  | Do not delete the pvc upon helm uninstall | `false` |
 | `persistence.extraMounts`            | Array of additional claims to mount | `[]` |
 | `resources`                | CPU/Memory resource requests/limits | `{}` |
 | `nodeSelector`             | Node labels for pod assignment | `{}` |
@@ -94,5 +96,12 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 ```console
 helm install --name my-release -f values.yaml stable/nzbget
 ```
+
+---
+**NOTE**
+
+If you get `Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: ...` it may be because you uninstalled the chart with `skipuninstall` enabled, you need to manually delete the pvc or use `existingClaim`.
+
+---
 
 Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/nzbget/values.yaml) file. It has several commented out suggested values.

--- a/charts/nzbget/templates/config-pvc.yaml
+++ b/charts/nzbget/templates/config-pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "nzbget.fullname" . }}-config
+  {{- if .Values.persistence.config.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "nzbget.name" . }}
     helm.sh/chart: {{ include "nzbget.chart" . }}

--- a/charts/nzbget/templates/downloads-pvc.yaml
+++ b/charts/nzbget/templates/downloads-pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "nzbget.fullname" . }}-downloads
+  {{- if .Values.persistence.downloads.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "nzbget.name" . }}
     helm.sh/chart: {{ include "nzbget.chart" . }}

--- a/charts/nzbget/values.yaml
+++ b/charts/nzbget/values.yaml
@@ -79,6 +79,8 @@ persistence:
     # existingClaim: your-claim
     accessMode: ReadWriteOnce
     size: 1Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
   downloads:
     enabled: true
     ## nzbget torrents downloads volume configuration
@@ -96,6 +98,8 @@ persistence:
     # subPath: some-subpath
     accessMode: ReadWriteOnce
     size: 10Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
   extraMounts: []
   ## Include additional claims that can be mounted inside the
   ## pod. This is useful if you wish to use different paths with categories

--- a/charts/nzbhydra2/Chart.yaml
+++ b/charts/nzbhydra2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.14.2-ls59
 description: Usenet meta search
 name: nzbhydra2
-version: 2.1.0
+version: 2.2.0
 keywords:
   - nzbhydra2
   - usenet

--- a/charts/nzbhydra2/README.md
+++ b/charts/nzbhydra2/README.md
@@ -65,6 +65,7 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `persistence.config.subPath`  | Mount a sub directory of the persistent volume if set | `""` |
 | `persistence.config.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.config.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.config.skipuninstall`  | Do not delete the pvc upon helm uninstall | `false` |
 | `resources`                | CPU/Memory resource requests/limits | `{}` |
 | `nodeSelector`             | Node labels for pod assignment | `{}` |
 | `tolerations`              | Toleration labels for pod assignment | `[]` |
@@ -85,5 +86,12 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 ```console
 helm install --name my-release -f values.yaml billimek/nzbhydra2
 ```
+
+---
+**NOTE**
+
+If you get `Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: ...` it may be because you uninstalled the chart with `skipuninstall` enabled, you need to manually delete the pvc or use `existingClaim`.
+
+---
 
 Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/nzbhydra2/values.yaml) file. It has several commented out suggested values.

--- a/charts/nzbhydra2/templates/config-pvc.yaml
+++ b/charts/nzbhydra2/templates/config-pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "nzbhydra2.fullname" . }}-config
+  {{- if .Values.persistence.config.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "nzbhydra2.name" . }}
     helm.sh/chart: {{ include "nzbhydra2.chart" . }}

--- a/charts/nzbhydra2/values.yaml
+++ b/charts/nzbhydra2/values.yaml
@@ -86,6 +86,8 @@ persistence:
     ## This is especially handy for volume plugins that don't natively support sub mounting (like glusterfs).
     ##
     subPath: ""
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/ombi/Chart.yaml
+++ b/charts/ombi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 3.0.5020-ls5
 description: Want a Movie or TV Show on Plex or Emby? Use Ombi!
 name: ombi
-version: 2.1.1
+version: 2.2.0
 keywords:
   - ombi
   - plex

--- a/charts/ombi/README.md
+++ b/charts/ombi/README.md
@@ -64,6 +64,7 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `persistence.config.subPath`  | Mount a sub directory of the persistent volume if set | `""` |
 | `persistence.config.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.config.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.config.skipuninstall`  | Do not delete the pvc upon helm uninstall | `false` |
 | `resources`                | CPU/Memory resource requests/limits | `{}` |
 | `nodeSelector`             | Node labels for pod assignment | `{}` |
 | `tolerations`              | Toleration labels for pod assignment | `[]` |
@@ -84,5 +85,12 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 ```console
 helm install --name my-release -f values.yaml billimek/ombi
 ```
+
+---
+**NOTE**
+
+If you get `Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: ...` it may be because you uninstalled the chart with `skipuninstall` enabled, you need to manually delete the pvc or use `existingClaim`.
+
+---
 
 Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/ombi/values.yaml) file. It has several commented out suggested values.

--- a/charts/ombi/templates/config-pvc.yaml
+++ b/charts/ombi/templates/config-pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "ombi.fullname" . }}-config
+  {{- if .Values.persistence.config.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "ombi.name" . }}
     helm.sh/chart: {{ include "ombi.chart" . }}

--- a/charts/ombi/values.yaml
+++ b/charts/ombi/values.yaml
@@ -84,6 +84,8 @@ persistence:
     ## This is especially handy for volume plugins that don't natively support sub mounting (like glusterfs).
     ##
     subPath: ""
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/qbittorrent/Chart.yaml
+++ b/charts/qbittorrent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 14.2.0.99201912180418-6819-118af03ubuntu18.04.1-ls62
 description: qBittorrent is a cross-platform free and open-source BitTorrent client
 name: qbittorrent
-version: 3.1.1
+version: 3.2.0
 keywords:
   - qbittorrent
   - torrrent

--- a/charts/qbittorrent/README.md
+++ b/charts/qbittorrent/README.md
@@ -74,12 +74,14 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `persistence.config.subPath`  | Mount a sub directory of the persistent volume if set | `""` |
 | `persistence.config.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.config.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.config.skipuninstall`  | Do not delete the pvc upon helm uninstall | `false` |
 | `persistence.downloads.enabled`      | Use persistent volume to store configuration data | `true` |
 | `persistence.downloads.size`         | Size of persistent volume claim | `10Gi` |
 | `persistence.downloads.existingClaim`| Use an existing PVC to persist data | `nil` |
 | `persistence.downloads.subPath`  | Mount a sub directory of the persistent volume if set | `""` |
 | `persistence.downloads.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.downloads.accessMode`   | Persistence access mode | `ReadWriteOnce` |
+| `persistence.downloads.skipuninstall`  | Do not delete the pvc upon helm uninstall | `false` |
 | `persistence.extraMounts`            | Array of additional claims to mount | `[]` |
 | `resources`                | CPU/Memory resource requests/limits | `{}` |
 | `nodeSelector`             | Node labels for pod assignment | `{}` |
@@ -101,5 +103,12 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 ```console
 helm install --name my-release -f values.yaml billimek/qbittorrent
 ```
+
+---
+**NOTE**
+
+If you get `Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: ...` it may be because you uninstalled the chart with `skipuninstall` enabled, you need to manually delete the pvc or use `existingClaim`.
+
+---
 
 Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/qbittorrent/values.yaml) file. It has several commented out suggested values.

--- a/charts/qbittorrent/templates/config-pvc.yaml
+++ b/charts/qbittorrent/templates/config-pvc.yaml
@@ -3,6 +3,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "qbittorrent.fullname" . }}-config
+  {{- if .Values.persistence.config.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "qbittorrent.name" . }}
     helm.sh/chart: {{ include "qbittorrent.chart" . }}

--- a/charts/qbittorrent/templates/downloads-pvc.yaml
+++ b/charts/qbittorrent/templates/downloads-pvc.yaml
@@ -3,6 +3,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "qbittorrent.fullname" . }}-downloads
+  {{- if .Values.persistence.downloads.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "qbittorrent.name" . }}
     helm.sh/chart: {{ include "qbittorrent.chart" . }}

--- a/charts/qbittorrent/values.yaml
+++ b/charts/qbittorrent/values.yaml
@@ -112,6 +112,8 @@ persistence:
     ## This is especially handy for volume plugins that don't natively support sub mounting (like glusterfs).
     ##
     subPath: ""
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
   downloads:
     enabled: true
     ## qbittorrent torrents downloads volume configuration
@@ -133,6 +135,8 @@ persistence:
     ## This is especially handy for volume plugins that don't natively support sub mounting (like glusterfs).
     ##
     subPath: ""
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
 
   extraMounts: []
   ## Include additional claims that can be mounted inside the

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: amd64-v0.2.0.1344-ls17
 description: Radarr is a movie downloading client
 name: radarr
-version: 3.0.2
+version: 3.1.0
 keywords:
   - radarr
   - usenet

--- a/charts/radarr/README.md
+++ b/charts/radarr/README.md
@@ -63,16 +63,19 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `persistence.config.existingClaim`| Use an existing PVC to persist data | `nil` |
 | `persistence.config.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.config.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.config.skipuninstall`  | Do not delete the pvc upon helm uninstall | `false` |
 | `persistence.downloads.enabled`      | Use persistent volume to store configuration data | `true` |
 | `persistence.downloads.size`         | Size of persistent volume claim | `10Gi` |
 | `persistence.downloads.existingClaim`| Use an existing PVC to persist data | `nil` |
 | `persistence.downloads.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.downloads.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.downloads.skipuninstall`  | Do not delete the pvc upon helm uninstall | `false` |
 | `persistence.movies.enabled`      | Use persistent volume to store configuration data | `true` |
 | `persistence.movies.size`         | Size of persistent volume claim | `10Gi` |
 | `persistence.movies.existingClaim`| Use an existing PVC to persist data | `nil` |
 | `persistence.movies.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.movies.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.movies.skipuninstall`  | Do not delete the pvc upon helm uninstall | `false` |
 | `persistence.extraExistingClaimMounts`  | Optionally add multiple existing claims | `[]` |
 | `resources`                | CPU/Memory resource requests/limits | `{}` |
 | `nodeSelector`             | Node labels for pod assignment | `{}` |
@@ -94,5 +97,12 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 ```console
 helm install --name my-release -f values.yaml stable/radarr
 ```
+
+---
+**NOTE**
+
+If you get `Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: ...` it may be because you uninstalled the chart with `skipuninstall` enabled, you need to manually delete the pvc or use `existingClaim`.
+
+---
 
 Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/radarr/values.yaml) file. It has several commented out suggested values.

--- a/charts/radarr/templates/config-pvc.yaml
+++ b/charts/radarr/templates/config-pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "radarr.fullname" . }}-config
+  {{- if .Values.persistence.config.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "radarr.name" . }}
     helm.sh/chart: {{ include "radarr.chart" . }}

--- a/charts/radarr/templates/downloads-pvc.yaml
+++ b/charts/radarr/templates/downloads-pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "radarr.fullname" . }}-downloads
+  {{- if .Values.persistence.downloads.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "radarr.name" . }}
     helm.sh/chart: {{ include "radarr.chart" . }}

--- a/charts/radarr/templates/movies-pvc.yaml
+++ b/charts/radarr/templates/movies-pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "radarr.fullname" . }}-movies
+  {{- if .Values.persistence.movies.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "radarr.name" . }}
     helm.sh/chart: {{ include "radarr.chart" . }}

--- a/charts/radarr/values.yaml
+++ b/charts/radarr/values.yaml
@@ -79,6 +79,8 @@ persistence:
     # existingClaim: your-claim
     accessMode: ReadWriteOnce
     size: 1Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
   downloads:
     enabled: true
     ## radarr downloads volume configuration
@@ -96,6 +98,8 @@ persistence:
     # subPath: some-subpath
     accessMode: ReadWriteOnce
     size: 10Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
   movies:
     enabled: true
     ## Directory where movies are persisted
@@ -113,6 +117,8 @@ persistence:
     # subPath: some-subpath
     accessMode: ReadWriteOnce
     size: 10Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
   extraExistingClaimMounts: []
     # - name: external-mount
     #   mountPath: /srv/external-mount

--- a/charts/rtorrent-flood/Chart.yaml
+++ b/charts/rtorrent-flood/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: rtorrent and flood co-located in the same deployment
 name: rtorrent-flood
-version: 4.0.1
+version: 4.1.0
 keywords:
   - rtorrent
   - flood

--- a/charts/rtorrent-flood/templates/config-pvc.yaml
+++ b/charts/rtorrent-flood/templates/config-pvc.yaml
@@ -3,6 +3,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "rtorrent-flood.fullname" . }}-config
+  {{- if .Values.persistence.config.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "rtorrent-flood.name" . }}
     helm.sh/chart: {{ include "rtorrent-flood.chart" . }}

--- a/charts/rtorrent-flood/templates/data-pvc.yaml
+++ b/charts/rtorrent-flood/templates/data-pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "rtorrent-flood.fullname" . }}-data
+  {{- if .Values.persistence.data.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "rtorrent-flood.name" . }}
     helm.sh/chart: {{ include "rtorrent-flood.chart" . }}

--- a/charts/rtorrent-flood/values.yaml
+++ b/charts/rtorrent-flood/values.yaml
@@ -114,6 +114,8 @@ persistence:
     # existingClaim: your-claim
     accessMode: ReadWriteOnce
     size: 1Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
   data:
     enabled: true
     ## torrents data volume configuration
@@ -131,6 +133,8 @@ persistence:
     # subPath: some-subpath
     accessMode: ReadWriteOnce
     size: 10Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
 
 nodeSelector: {}
 

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: amd64-2.0.0.5321-ls62
 description: Sonarr is a television show downloading client
 name: sonarr
-version: 3.0.2
+version: 3.1.0
 keywords:
   - sonarr
   - usenet

--- a/charts/sonarr/README.md
+++ b/charts/sonarr/README.md
@@ -63,16 +63,19 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `persistence.config.existingClaim`| Use an existing PVC to persist data | `nil` |
 | `persistence.config.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.config.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.config.skipuninstall`  | Do not delete the pvc upon helm uninstall | `false` |
 | `persistence.downloads.enabled`      | Use persistent volume for downloads | `true` |
 | `persistence.downloads.size`         | Size of persistent volume claim | `10Gi` |
 | `persistence.downloads.existingClaim`| Use an existing PVC to persist data | `nil` |
 | `persistence.downloads.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.downloads.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.downloads.skipuninstall`  | Do not delete the pvc upon helm uninstall | `false` |
 | `persistence.tv.enabled`      | Use persistent volume for tv show persistence | `true` |
 | `persistence.tv.size`         | Size of persistent volume claim | `10Gi` |
 | `persistence.tv.existingClaim`| Use an existing PVC to persist data | `nil` |
 | `persistence.tv.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.tv.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.tv.skipuninstall`  | Do not delete the pvc upon helm uninstall | `false` |
 | `persistence.extraExistingClaimMounts`  | Optionally add multiple existing claims | `[]` |
 | `resources`                | CPU/Memory resource requests/limits | `{}` |
 | `nodeSelector`             | Node labels for pod assignment | `{}` |
@@ -94,5 +97,12 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 ```console
 helm install --name my-release -f values.yaml stable/sonarr
 ```
+
+---
+**NOTE**
+
+If you get `Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: ...` it may be because you uninstalled the chart with `skipuninstall` enabled, you need to manually delete the pvc or use `existingClaim`.
+
+---
 
 Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/sonarr/values.yaml) file. It has several commented out suggested values.

--- a/charts/sonarr/templates/config-pvc.yaml
+++ b/charts/sonarr/templates/config-pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "sonarr.fullname" . }}-config
+  {{- if .Values.persistence.config.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "sonarr.name" . }}
     helm.sh/chart: {{ include "sonarr.chart" . }}

--- a/charts/sonarr/templates/downloads-pvc.yaml
+++ b/charts/sonarr/templates/downloads-pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "sonarr.fullname" . }}-downloads
+  {{- if .Values.persistence.downloads.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "sonarr.name" . }}
     helm.sh/chart: {{ include "sonarr.chart" . }}

--- a/charts/sonarr/templates/tv-pvc.yaml
+++ b/charts/sonarr/templates/tv-pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "sonarr.fullname" . }}-tv
+  {{- if .Values.persistence.tv.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "sonarr.name" . }}
     helm.sh/chart: {{ include "sonarr.chart" . }}

--- a/charts/sonarr/values.yaml
+++ b/charts/sonarr/values.yaml
@@ -79,6 +79,8 @@ persistence:
     # existingClaim: your-claim
     accessMode: ReadWriteOnce
     size: 1Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
   downloads:
     enabled: true
     ## sonarr downloads volume configuration
@@ -96,6 +98,8 @@ persistence:
     # subPath: some-subpath
     accessMode: ReadWriteOnce
     size: 10Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
   tv:
     enabled: true
     ## Directory where televion shows are persisted
@@ -113,6 +117,8 @@ persistence:
     # subPath: some-subpath
     accessMode: ReadWriteOnce
     size: 10Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
   extraExistingClaimMounts: []
     # - name: external-mount
     #   mountPath: /srv/external-mount

--- a/charts/tautulli/Chart.yaml
+++ b/charts/tautulli/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.1.44-ls34
 description: A Python based monitoring and tracking tool for Plex Media Server.
 name: tautulli
-version: 2.1.0
+version: 2.2.0
 keywords:
   - tautulli
   - plex

--- a/charts/tautulli/README.md
+++ b/charts/tautulli/README.md
@@ -64,6 +64,7 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `persistence.config.subPath`  | Mount a sub directory of the persistent volume if set | `""` |
 | `persistence.config.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.config.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.config.skipuninstall`  | Do not delete the pvc upon helm uninstall | `false` |
 | `resources`                | CPU/Memory resource requests/limits | `{}` |
 | `nodeSelector`             | Node labels for pod assignment | `{}` |
 | `tolerations`              | Toleration labels for pod assignment | `[]` |
@@ -84,5 +85,12 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 ```console
 helm install --name my-release -f values.yaml billimek/tautulli
 ```
+
+---
+**NOTE**
+
+If you get `Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: ...` it may be because you uninstalled the chart with `skipuninstall` enabled, you need to manually delete the pvc or use `existingClaim`.
+
+---
 
 Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/tautulli/values.yaml) file. It has several commented out suggested values.

--- a/charts/tautulli/templates/config-pvc.yaml
+++ b/charts/tautulli/templates/config-pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "tautulli.fullname" . }}-config
+  {{- if .Values.persistence.config.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "tautulli.name" . }}
     helm.sh/chart: {{ include "tautulli.chart" . }}

--- a/charts/tautulli/values.yaml
+++ b/charts/tautulli/values.yaml
@@ -83,6 +83,8 @@ persistence:
     ## This is especially handy for volume plugins that don't natively support sub mounting (like glusterfs).
     ##
     subPath: ""
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/zwave2mqtt/Chart.yaml
+++ b/charts/zwave2mqtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.0.0"
 description: Fully configurable Zwave to MQTT gateway and Control Panel using NodeJS and Vue
 name: zwave2mqtt
-version: 2.0.2
+version: 2.1.0
 keywords:
   - zwave
   - mqtt

--- a/charts/zwave2mqtt/templates/pvc.yaml
+++ b/charts/zwave2mqtt/templates/pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "zwave2mqtt.fullname" . }}
+  {{- if .Values.persistence.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "zwave2mqtt.name" . }}
     helm.sh/chart: {{ include "zwave2mqtt.chart" . }}

--- a/charts/zwave2mqtt/values.yaml
+++ b/charts/zwave2mqtt/values.yaml
@@ -47,6 +47,8 @@ persistence:
   # existingClaim: your-claim
   accessMode: ReadWriteOnce
   size: 1Gi
+  ## Do not delete the pvc upon helm uninstall
+  skipuninstall: false
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Signed-off-by: Julien DOCHE <julien.doche@gmail.com>

This implements issue #168 by adding the `skipuninstall` value which adds the
`"helm.sh/resource-policy": keep` annotation to the created pvc.

- [x] Chart Version bumped
- [x] Variables are documented in the README.md
