### PR TITLE
[nzbhydra2] update to use new docker image and latest version

### DIFF
--- a/charts/nzbhydra2/Chart.yaml
+++ b/charts/nzbhydra2/Chart.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
-appVersion: v2.14.2-ls59
+appVersion: v2.22.2-ls9
 description: Usenet meta search
 name: nzbhydra2
-version: 2.2.0
+version: 2.3.0
 keywords:
   - nzbhydra2
   - usenet
 home: https://github.com/billimek/billimek-charts/tree/master/charts/nzbhydra2
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/hydra-icon.png
 sources:
-  - https://hub.docker.com/r/linuxserver/hydra2/
+  - https://hub.docker.com/r/linuxserver/nzbhydra2/
   - https://github.com/theotherp/nzbhydra2
 maintainers:
   - name: billimek

--- a/charts/nzbhydra2/README.md
+++ b/charts/nzbhydra2/README.md
@@ -34,7 +34,7 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | Parameter                  | Description                         | Default                                                 |
 |----------------------------|-------------------------------------|---------------------------------------------------------|
 | `image.repository`         | Image repository | `linuxserver/hydra2` |
-| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/linuxserver/hydra2/tags/).| `v0.12.1132-ls37`|
+| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/linuxserver/nzbhydra2/tags/).| `v2.22.2-ls9`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `strategyType`             | Specifies the strategy used to replace old Pods by new ones | `Recreate` |
 | `timezone`                 | Timezone the nzbhydra2 instance should run as, e.g. 'America/New_York' | `UTC` |

--- a/charts/nzbhydra2/values.yaml
+++ b/charts/nzbhydra2/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: linuxserver/hydra2
-  tag: v2.14.2-ls59
+  repository: linuxserver/nzbhydra2
+  tag: v2.22.2-ls9
   pullPolicy: IfNotPresent
 
 # upgrade strategy type (e.g. Recreate or RollingUpdate)


### PR DESCRIPTION
#### Special notes for your reviewer:
linuxserver.io deprecated the hydra2 image and started updating 'nzbhydra2' instead. This updates relevant pieces of information and values.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
