### PR TITLE
[home-assistant] Default home-assistant to latest

### DIFF
--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: homeassistant/home-assistant
-  tag: 0.110.6
+  tag: latest
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Alternatively we can go for: `0.111.4` or  `stable`

#### Special notes for your reviewer:

#### Checklist

- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
