### PR TITLE
[sonarr] Fix liveness and readiness probes on basic auth deployment

### DIFF
--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.0.0.5344-ls60
 description: Sonarr is a television show downloading client
 name: sonarr
-version: 4.1.0
+version: 4.1.1
 keywords:
   - sonarr
   - usenet

--- a/charts/sonarr/templates/deployment.yaml
+++ b/charts/sonarr/templates/deployment.yaml
@@ -43,15 +43,13 @@ spec:
               containerPort: 8989
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: http
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
           readinessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: http
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             failureThreshold: {{ .Values.probes.readiness.failureThreshold }}


### PR DESCRIPTION
Once basic auth enabled, deployment fails because the probes wait for a successful status (2xx or 3xx):

> HTTP probe failed with statuscode: 401

This changes httpGet to tcpSocket, making it identical to radarr and lidarr charts health checks.