### PR TITLE
[plex] fix port definition indentation

### DIFF
--- a/charts/plex/Chart.yaml
+++ b/charts/plex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.19.1.2645-ccb6eb67e
 description: Plex Media Server
 name: plex
-version: 1.3.1
+version: 1.3.2
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/plex/templates/deployment.yaml
+++ b/charts/plex/templates/deployment.yaml
@@ -64,8 +64,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: pms
-              containerPort: 32400
+          - name: pms
+            containerPort: 32400
           env:
           - name: TZ
             value: "{{ .Values.timezone }}"


### PR DESCRIPTION
#### Special notes for your reviewer:
After upgrading plex from chart 1.0.0 to 1.3.1 plex stopped responding.
In my deployment the port key wasn't set.
After fixing the indentation, the deployment get the ports exposed again.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
