### PR TITLE
[plex] Allow custom extraMount paths

### DIFF
--- a/charts/plex/Chart.yaml
+++ b/charts/plex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.19.1.2645-ccb6eb67e
 description: Plex Media Server
 name: plex
-version: 1.5.3
+version: 1.6.0
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/plex/Chart.yaml
+++ b/charts/plex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.19.1.2645-ccb6eb67e
 description: Plex Media Server
 name: plex
-version: 1.5.2
+version: 1.5.3
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/plex/templates/deployment.yaml
+++ b/charts/plex/templates/deployment.yaml
@@ -213,6 +213,7 @@ spec:
           - mountPath: "/{{ .name }}"
             name: "{{ .name }}"
           {{- end }}
+          {{- end }}
           - name: shared
             mountPath: /shared
           {{- if .Values.plexPreferences.enabled }}
@@ -300,4 +301,4 @@ spec:
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }} 
+    {{- end }}

--- a/charts/plex/templates/deployment.yaml
+++ b/charts/plex/templates/deployment.yaml
@@ -209,6 +209,10 @@ spec:
           - mountPath: "/data-{{ .name }}"
             name: "extradata-{{ .name }}"
           {{- end }}
+          {{-  range .Values.persistence.extraMounts }}
+          - mountPath: ""/{{ .name }}"
+            name: "{{ .name }}"
+          {{- end }}
           - name: shared
             mountPath: /shared
           {{- if .Values.plexPreferences.enabled }}
@@ -266,6 +270,11 @@ spec:
 {{- else }}
           claimName: "extradata-{{ .name }}"
 {{- end }}
+{{- end }}
+{{- range .Values.persistence.extraMounts }}
+      - name: {{ .name }}
+        persistentVolumeClaim:
+          claimName: {{ .claimName }}
 {{- end }}
       - name: shared
         emptyDir: {}

--- a/charts/plex/templates/deployment.yaml
+++ b/charts/plex/templates/deployment.yaml
@@ -300,4 +300,4 @@ spec:
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+    {{- end }} 

--- a/charts/plex/templates/deployment.yaml
+++ b/charts/plex/templates/deployment.yaml
@@ -213,7 +213,6 @@ spec:
           - mountPath: "/{{ .name }}"
             name: "{{ .name }}"
           {{- end }}
-          {{- end }}
           - name: shared
             mountPath: /shared
           {{- if .Values.plexPreferences.enabled }}
@@ -270,6 +269,7 @@ spec:
           claimName: "{{ .claimName }}"
 {{- else }}
           claimName: "extradata-{{ .name }}"
+{{- end }}
 {{- end }}
 {{- range .Values.persistence.extraMounts }}
       - name: {{ .name }}

--- a/charts/plex/templates/deployment.yaml
+++ b/charts/plex/templates/deployment.yaml
@@ -210,7 +210,7 @@ spec:
             name: "extradata-{{ .name }}"
           {{- end }}
           {{-  range .Values.persistence.extraMounts }}
-          - mountPath: ""/{{ .name }}"
+          - mountPath: "/{{ .name }}"
             name: "{{ .name }}"
           {{- end }}
           - name: shared

--- a/charts/plex/templates/deployment.yaml
+++ b/charts/plex/templates/deployment.yaml
@@ -270,7 +270,6 @@ spec:
 {{- else }}
           claimName: "extradata-{{ .name }}"
 {{- end }}
-{{- end }}
 {{- range .Values.persistence.extraMounts }}
       - name: {{ .name }}
         persistentVolumeClaim:

--- a/charts/plex/values.yaml
+++ b/charts/plex/values.yaml
@@ -209,6 +209,13 @@ persistence:
     # - claimName: "special-tv"
     #   name: 'foo'
 
+  extraMounts: []
+    ## Include additional claims that can be mounted inside the
+    ## pod. This is useful if you wish to use different paths with categories
+    ## Claim will me mounted as /{name}
+    # - name: video
+    #   claimName: video-claim
+
   config:
     # Optionally specify claimName to manually override the PVC to be used for
     # the config directory. If claimName is specified, storageClass and size


### PR DESCRIPTION
#### Special notes for your reviewer:
Allows mounting specific paths so I don't have to recreate my Plex database to point to a `/data` location. Kept the original `'/data-{name}` option as well for legacy so it shouldn't affect people who still use that.

Tried to mimic NZBGet's implementation. Think I caught everything, first time editing a chart.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[radarr]`)
