### PR TITLE
[ser2sock] Baud rate as a variable. Allows for other serial devices

### DIFF
--- a/charts/ser2sock/Chart.yaml
+++ b/charts/ser2sock/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: Serial to Socket Redirector
 name: ser2sock
-version: 1.0.2
+version: 1.1.2
 keywords:
   - ser2sock
 home: https://github.com/billimek/billimek-charts/tree/master/charts/ser2sock

--- a/charts/ser2sock/Chart.yaml
+++ b/charts/ser2sock/Chart.yaml
@@ -2,7 +2,15 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: Serial to Socket Redirector
 name: ser2sock
+<<<<<<< HEAD
 version: 1.1.2
+=======
+<<<<<<< HEAD
+version: 1.1.0
+=======
+version: 1.1.2
+>>>>>>> 3830980... [ser2sock] Added baudRate as a values option
+>>>>>>> 922add2... [ser2sock] Add baud rate as variable
 keywords:
   - ser2sock
 home: https://github.com/billimek/billimek-charts/tree/master/charts/ser2sock

--- a/charts/ser2sock/Chart.yaml
+++ b/charts/ser2sock/Chart.yaml
@@ -2,15 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: Serial to Socket Redirector
 name: ser2sock
-<<<<<<< HEAD
-version: 1.1.2
-=======
-<<<<<<< HEAD
 version: 1.1.0
-=======
-version: 1.1.2
->>>>>>> 3830980... [ser2sock] Added baudRate as a values option
->>>>>>> 922add2... [ser2sock] Add baud rate as variable
 keywords:
   - ser2sock
 home: https://github.com/billimek/billimek-charts/tree/master/charts/ser2sock

--- a/charts/ser2sock/templates/deployment.yaml
+++ b/charts/ser2sock/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - name: LISTENER_PORT
               value: "10000"
             - name: BAUD_RATE
-              value: "115200"
+              value: "{{ .Values.baudRate }}"
             - name: SERIAL_DEVICE
               value: "/dev/ttyUSB0"
             - name: PUID

--- a/charts/ser2sock/values.yaml
+++ b/charts/ser2sock/values.yaml
@@ -17,6 +17,7 @@ fullnameOverride: ""
 device: "/dev/ttyUSB0"
 puid: "1001"
 pgid: "1001"
+baudRate: 115200
 
 service:
   type: ClusterIP


### PR DESCRIPTION
#### Special notes for your reviewer:
Allowed me to use a Nortek zigbee/zwave device. Probably useful for other stuff too.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
