### PR TITLE
[plex] Allow full mount path ability

### DIFF
--- a/charts/plex/Chart.yaml
+++ b/charts/plex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.19.1.2645-ccb6eb67e
 description: Plex Media Server
 name: plex
-version: 1.6.0
+version: 1.6.1
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/plex/templates/deployment.yaml
+++ b/charts/plex/templates/deployment.yaml
@@ -210,7 +210,7 @@ spec:
             name: "extradata-{{ .name }}"
           {{- end }}
           {{-  range .Values.persistence.extraMounts }}
-          - mountPath: "/{{ .name }}"
+          - mountPath: "/{{ .mountPath }}"
             name: "{{ .name }}"
           {{- end }}
           - name: shared

--- a/charts/plex/values.yaml
+++ b/charts/plex/values.yaml
@@ -212,9 +212,10 @@ persistence:
   extraMounts: []
     ## Include additional claims that can be mounted inside the
     ## pod. This is useful if you wish to use different paths with categories
-    ## Claim will me mounted as /{name}
+    ## Claim will me mounted as /{mountPath}
     # - name: video
     #   claimName: video-claim
+    #   mountPath: mnt/path/in/pod
 
   config:
     # Optionally specify claimName to manually override the PVC to be used for


### PR DESCRIPTION
#### Special notes for your reviewer:
Helm only allows the name to be a DNS compatible name, so no slashes allowed for subpaths. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)