### PR TITLE
[tautulli] Allow existing mount option

### DIFF
--- a/charts/tautulli/Chart.yaml
+++ b/charts/tautulli/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.1.44-ls34
 description: A Python based monitoring and tracking tool for Plex Media Server.
 name: tautulli
-version: 2.2.0
+version: 2.3.0
 keywords:
   - tautulli
   - plex

--- a/charts/tautulli/templates/deployment.yaml
+++ b/charts/tautulli/templates/deployment.yaml
@@ -66,7 +66,12 @@ spec:
               name: config
               {{- if .Values.persistence.config.subPath }}
               subPath: "{{ .Values.persistence.config.subPath }}"
-              {{- end }}              
+              {{- end }}
+            {{- range .Values.persistence.extraExistingClaimMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly }}
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:
@@ -77,6 +82,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
+      {{- range .Values.persistence.extraExistingClaimMounts }}
+      - name: {{ .name }}
+        persistentVolumeClaim:
+          claimName: {{ .existingClaim }}
+      {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/tautulli/values.yaml
+++ b/charts/tautulli/values.yaml
@@ -85,6 +85,13 @@ persistence:
     subPath: ""
     ## Do not delete the pvc upon helm uninstall
     skipuninstall: false
+  extraExistingClaimMounts: []
+    # - name: external-mount
+    #   mountPath: /srv/external-mount
+    ## A manually managed Persistent Volume and Claim
+    ## If defined, PVC must be created manually before volume will be bound
+    #   existingClaim:
+    #   readOnly: true
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
#### Special notes for your reviewer:
Originally was going to allow Plex logs to be seen by Tautulli (gives more logging ability).  Could be useful for other things like mounting a scripts folder for notification actions.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)