### PR TITLE
[nzbget] Add openvpn sidecar option

### DIFF
--- a/charts/nzbget/Chart.yaml
+++ b/charts/nzbget/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v21.0-ls14
 description: NZBGet is a Usenet downloader client
 name: nzbget
-version: 3.2.2
+version: 3.3.0
 keywords:
   - nzbget
   - usenet

--- a/charts/nzbget/templates/deployment.yaml
+++ b/charts/nzbget/templates/deployment.yaml
@@ -79,6 +79,28 @@ spec:
             {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+        {{- if .Values.openvpn.enabled }}
+        - name: openvpn
+          image: "{{ .Values.openvpn.image.repository }}:{{ .Values.openvpn.image.tag }}"
+          imagePullPolicy: {{ .Values.openvpn.image.pullPolicy }}
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN"]
+          {{- if .Values.openvpn.env }}
+          envFrom:
+          - secretRef:
+              name: {{ template "nzbget.fullname" . }}-openvpnenv
+          {{- end }}
+          {{- if .Values.openvpn.vpnConf }}
+          volumeMounts:
+          - name: openvpnconf
+            mountPath: /vpn/vpn.conf
+            subPath: vpnConf
+          {{- end }}
+          env:
+          - name: NETWORK_POLICY_ENABLED
+            value: {{ .Values.openvpn.networkPolicy.enabled | quote }}
+        {{- end }}
       volumes:
       - name: config
       {{- if .Values.persistence.config.enabled }}
@@ -93,6 +115,11 @@ spec:
           claimName: {{ if .Values.persistence.downloads.existingClaim }}{{ .Values.persistence.downloads.existingClaim }}{{- else }}{{ template "nzbget.fullname" . }}-downloads{{- end }}
       {{- else }}
         emptyDir: {}
+      {{ end }}
+      {{- if .Values.openvpn.vpnConf }}
+      - name: openvpnconf
+        configMap:
+          name: {{ template "nzbget.fullname" . }}-openvpnconf
       {{ end }}
      {{- range .Values.persistence.extraMounts }}
       - name: {{ .name }}

--- a/charts/nzbget/templates/openvpn-config.yaml
+++ b/charts/nzbget/templates/openvpn-config.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.openvpn.enabled .Values.openvpn.vpnConf}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nzbget.fullname" . }}-openvpnconf
+  labels:
+    app.kubernetes.io/name: {{ include "nzbget.name" . }}
+    helm.sh/chart: {{ include "nzbget.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  {{- if .Values.openvpn.vpnConf }}
+  vpnConf: |-
+    {{- .Values.openvpn.vpnConf | nindent 4}}
+  {{- end }}
+{{- end -}}

--- a/charts/nzbget/templates/openvpn-env.yaml
+++ b/charts/nzbget/templates/openvpn-env.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.openvpn.enabled ( or .Values.openvpn.env .Values.openvpn.auth )}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "nzbget.fullname" . }}-openvpnenv
+  labels:
+    app.kubernetes.io/name: {{ include "nzbget.name" . }}
+    helm.sh/chart: {{ include "nzbget.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  {{- if .Values.openvpn.auth }}
+  VPN_AUTH: {{ .Values.openvpn.auth | b64enc }}
+  {{- end }}
+  {{- if .Values.openvpn.env }}
+  {{- range $k, $v := .Values.openvpn.env }}
+  {{ $k }}: {{ $v | b64enc }}
+  {{- end }}
+  {{- end -}}
+{{- end -}}

--- a/charts/nzbget/templates/openvpn-networkpolicy.yaml
+++ b/charts/nzbget/templates/openvpn-networkpolicy.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.openvpn.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ template "nzbget.fullname" . }}-deny-all-netpol
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "nzbget.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+  - Egress
+  egress:
+  {{- if .Values.openvpn.networkPolicy.egress }} 
+  {{- .Values.openvpn.networkPolicy.egress | toYaml | nindent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/charts/nzbget/values.yaml
+++ b/charts/nzbget/values.yaml
@@ -64,7 +64,7 @@ ingress:
 
 openvpn:
   # Enables an openvpn sidecar that when configured properly will provide a
-  # Secure outbound VPN for use by NZBGet. 
+  # Secure outbound VPN for use by NZBGet.
   enabled: false
 
   image:
@@ -79,14 +79,14 @@ openvpn:
   # TZ: EST5EDT
 
   # Provide a customized vpn.conf file to be used by openvpn.
-  vpnConf: # |-
+  vpnConf:  # |-
     # Some Example Config
     # remote greatvpnhost.com 8888
     # auth-user-pass
     # Cipher AES
 
   # Credentials to connect to the VPN Service (used with -a)
-  auth: # "user;password"
+  auth:  # "user;password"
 
   # If set to true, will deploy a network policy that blocks all outbound
   # traffic except traffic specified as allowed

--- a/charts/nzbget/values.yaml
+++ b/charts/nzbget/values.yaml
@@ -62,6 +62,52 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+openvpn:
+  # Enables an openvpn sidecar that when configured properly will provide a
+  # Secure outbound VPN for use by NZBGet. 
+  enabled: false
+
+  image:
+    repository: dperson/openvpn-client
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  # All variables specified here will be added to the openvpn sidecar container
+  # Ref https://hub.docker.com/r/dperson/openvpn-client for all config values
+  env: []
+  # DNS: "true"
+  # TZ: EST5EDT
+
+  # Provide a customized vpn.conf file to be used by openvpn.
+  vpnConf: # |-
+    # Some Example Config
+    # remote greatvpnhost.com 8888
+    # auth-user-pass
+    # Cipher AES
+
+  # Credentials to connect to the VPN Service (used with -a)
+  auth: # "user;password"
+
+  # If set to true, will deploy a network policy that blocks all outbound
+  # traffic except traffic specified as allowed
+  networkPolicy:
+    enabled: false
+
+    # The egress configuration for your network policy, All outbound traffic
+    # From the pod will be blocked unless specified here. Your cluster must
+    # have a CNI that supports network policies (Canal, Calico, etc...)
+    # https://kubernetes.io/docs/concepts/services-networking/network-policies/
+    # https://github.com/ahmetb/kubernetes-network-policy-recipes
+    egress:
+      # - to:
+      #   - ipBlock:
+      #       cidr: 0.0.0.0/0
+      #   ports:
+      #   - port: 53
+      #     protocol: UDP
+      #   - port: 53
+      #     protocol: TCP
+
 persistence:
   config:
     enabled: true


### PR DESCRIPTION
I needed an openvpn sidecar container for nzbget to function properly on my network. Since I had done the work i figured it would be good to publish and see if the community saw this as useful and wanted to merge it in. If not useful or applicable we can close this.

#### Special notes for your reviewer:

- The default is that the openvpn sidecar is disabled and all configs return blank. No additional objects are created if `.Values.openvpn.enabled = false`

- The networkpolicy object defaults to `Deny All` unless traffic is specified as allowed.

#### Checklist
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Variables are documented in the values.yaml
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
