### PR TITLE
Ingress labels defined in READMEs aren't actually applied to ingresses

### DIFF
--- a/charts/bazarr/Chart.yaml
+++ b/charts/bazarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.8.4.2-ls72
 description: Bazarr is a companion application to Sonarr and Radarr. It manages and downloads subtitles based on your requirements
 name: bazarr
-version: 2.0.0
+version: 2.0.1
 keywords:
   - bazarr
   - radarr

--- a/charts/bazarr/templates/ingress.yaml
+++ b/charts/bazarr/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "bazarr.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/bazarr/values.yaml
+++ b/charts/bazarr/values.yaml
@@ -54,6 +54,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
   hosts:
     - chart-example.local

--- a/charts/couchpotato/Chart.yaml
+++ b/charts/couchpotato/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 7260c12f-ls33
 description: couchpotato is a movie downloading client
 name: couchpotato
-version: 1.0.0
+version: 1.0.1
 keywords:
   - couchpotato
   - usenet

--- a/charts/couchpotato/templates/ingress.yaml
+++ b/charts/couchpotato/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "couchpotato.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/couchpotato/values.yaml
+++ b/charts/couchpotato/values.yaml
@@ -54,6 +54,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
   hosts:
     - chart-example.local

--- a/charts/duplicati/Chart.yaml
+++ b/charts/duplicati/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.0.5.1-2.0.5.1_beta_2020-01-18-ls58
 description: Store securely encrypted backups on cloud storage services!
 name: duplicati
-version: 1.0.0
+version: 1.0.1
 keywords:
   - duplicati
 home: https://github.com/billimek/billimek-charts/tree/master/charts/duplicati

--- a/charts/duplicati/templates/ingress.yaml
+++ b/charts/duplicati/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "duplicati.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/duplicati/values.yaml
+++ b/charts/duplicati/values.yaml
@@ -55,6 +55,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
   hosts:
     - chart-example.local

--- a/charts/grocy/Chart.yaml
+++ b/charts/grocy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.6.1
 description: ERP beyond your fridge - grocy is a web-based self-hosted groceries & household management solution for your home
 name: grocy
-version: 1.0.0
+version: 1.0.1
 keywords:
   - grocy
 home: https://github.com/billimek/billimek-charts/tree/master/charts/grocy

--- a/charts/grocy/templates/ingress.yaml
+++ b/charts/grocy/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "grocy.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/grocy/values.yaml
+++ b/charts/grocy/values.yaml
@@ -56,6 +56,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  values: {}
   path: /
   hosts:
     - chart-example.local

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.2.2-ls84
 description: An Application dashboard and launcher
 name: heimdall
-version: 1.0.1
+version: 1.0.2
 keywords:
   - heimdall
 home: https://github.com/billimek/billimek-charts/tree/master/charts/heimdall

--- a/charts/heimdall/templates/ingress.yaml
+++ b/charts/heimdall/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "heimdall.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -54,6 +54,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
   hosts:
     - chart-example.local

--- a/charts/jackett/Chart.yaml
+++ b/charts/jackett/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.13.446-ls55
 description: API Support for your favorite torrent trackers
 name: jackett
-version: 2.3.0
+version: 2.3.1
 keywords:
   - jackett
   - torrent

--- a/charts/jackett/templates/ingress.yaml
+++ b/charts/jackett/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "jackett.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/jackett/values.yaml
+++ b/charts/jackett/values.yaml
@@ -56,6 +56,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
   hosts:
     - chart-example.local

--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v10.5.3-ls45
 description: Jellyfin is a Free Software Media System
 name: jellyfin
-version: 1.0.0
+version: 1.0.1
 keywords:
   - Jellyfin
   - mediaplayer

--- a/charts/jellyfin/templates/ingress.yaml
+++ b/charts/jellyfin/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "jellyfin.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -55,6 +55,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
   hosts:
     - chart-example.local

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.7.1.1381-ls7
 description: Looks and smells like Sonarr but made for music.
 name: lidarr
-version: 2.0.0
+version: 2.0.1
 keywords:
   - lidarr
   - usenet

--- a/charts/lidarr/templates/ingress.yaml
+++ b/charts/lidarr/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "lidarr.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/lidarr/values.yaml
+++ b/charts/lidarr/values.yaml
@@ -54,6 +54,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
   hosts:
     - chart-example.local

--- a/charts/nzbget/Chart.yaml
+++ b/charts/nzbget/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v21.0-ls14
 description: NZBGet is a Usenet downloader client
 name: nzbget
-version: 3.3.0
+version: 3.3.1
 keywords:
   - nzbget
   - usenet

--- a/charts/nzbget/templates/ingress.yaml
+++ b/charts/nzbget/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "nzbget.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/nzbget/values.yaml
+++ b/charts/nzbget/values.yaml
@@ -54,6 +54,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
   hosts:
     - chart-example.local

--- a/charts/nzbhydra2/Chart.yaml
+++ b/charts/nzbhydra2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.22.2-ls9
 description: Usenet meta search
 name: nzbhydra2
-version: 2.3.0
+version: 2.3.1
 keywords:
   - nzbhydra2
   - usenet

--- a/charts/nzbhydra2/templates/ingress.yaml
+++ b/charts/nzbhydra2/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "nzbhydra2.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/nzbhydra2/values.yaml
+++ b/charts/nzbhydra2/values.yaml
@@ -56,6 +56,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
   hosts:
     - chart-example.local

--- a/charts/ombi/Chart.yaml
+++ b/charts/ombi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v3.0.4892-ls61
 description: Want a Movie or TV Show on Plex or Emby? Use Ombi!
 name: ombi
-version: 2.2.1
+version: 2.2.2
 keywords:
   - ombi
   - plex

--- a/charts/ombi/templates/ingress.yaml
+++ b/charts/ombi/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "ombi.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/ombi/values.yaml
+++ b/charts/ombi/values.yaml
@@ -60,6 +60,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
   hosts:
     - chart-example.local

--- a/charts/qbittorrent/Chart.yaml
+++ b/charts/qbittorrent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 14.2.0.99201912180418-6819-118af03ubuntu18.04.1-ls62
 description: qBittorrent is a cross-platform free and open-source BitTorrent client
 name: qbittorrent
-version: 3.2.0
+version: 3.2.1
 keywords:
   - qbittorrent
   - torrrent

--- a/charts/qbittorrent/templates/ingress.yaml
+++ b/charts/qbittorrent/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "qbittorrent.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/qbittorrent/values.yaml
+++ b/charts/qbittorrent/values.yaml
@@ -83,6 +83,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
   hosts:
     - chart-example.local

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.2.0.1480-ls58
 description: Radarr is a movie downloading client
 name: radarr
-version: 4.1.1
+version: 4.1.2
 keywords:
   - radarr
   - usenet

--- a/charts/radarr/templates/ingress.yaml
+++ b/charts/radarr/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "radarr.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/radarr/values.yaml
+++ b/charts/radarr/values.yaml
@@ -72,6 +72,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
   hosts:
     - chart-example.local

--- a/charts/sabnzbd/Chart.yaml
+++ b/charts/sabnzbd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.3.9
 description: Free and easy binary newsreader
 name: sabnzbd
-version: 1.0.0
+version: 1.0.1
 keywords:
   - sabnzbd
   - usenet

--- a/charts/sabnzbd/templates/ingress.yaml
+++ b/charts/sabnzbd/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "sabnzbd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/sabnzbd/values.yaml
+++ b/charts/sabnzbd/values.yaml
@@ -54,6 +54,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
   hosts:
     - chart-example.local

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.0.0.5344-ls60
 description: Sonarr is a television show downloading client
 name: sonarr
-version: 4.1.1
+version: 4.1.2
 keywords:
   - sonarr
   - usenet

--- a/charts/sonarr/templates/ingress.yaml
+++ b/charts/sonarr/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "sonarr.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/sonarr/values.yaml
+++ b/charts/sonarr/values.yaml
@@ -74,6 +74,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
   hosts:
     - chart-example.local

--- a/charts/tautulli/Chart.yaml
+++ b/charts/tautulli/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.1.44-ls34
 description: A Python based monitoring and tracking tool for Plex Media Server.
 name: tautulli
-version: 2.3.0
+version: 2.3.1
 keywords:
   - tautulli
   - plex

--- a/charts/tautulli/templates/ingress.yaml
+++ b/charts/tautulli/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ include "tautulli.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ toYaml .Values.ingress.labels | nindent 4 }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/tautulli/values.yaml
+++ b/charts/tautulli/values.yaml
@@ -54,6 +54,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   path: /
   hosts:
     - chart-example.local


### PR DESCRIPTION
#### Special notes for your reviewer:

Any ingress labels that appear in READMEs are now actually applied to ingresses

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[radarr]`)
