### PR TITLE
[plex] Issue 320 Arm support via linuxserver/plex

### DIFF
--- a/charts/plex/Chart.yaml
+++ b/charts/plex/Chart.yaml
@@ -1,15 +1,16 @@
 apiVersion: v1
-appVersion: 1.19.1.2645-ccb6eb67e
+appVersion: 1.19.5.3112-b23ab3896-ls113
 description: Plex Media Server
 name: plex
-version: 1.7.2
+version: 1.7.3
 keywords:
   - plex
 home: https://plex.tv/
 icon: https://www.plex.tv/wp-content/uploads/2018/01/pmp-icon-1.png
 sources:
   - https://github.com/billimek/billimek-charts/tree/master/charts/plex
-  - https://hub.docker.com/r/plexinc/pms-docker/
+  - https://hub.docker.com/r/linuxserver/plex/
 maintainers:
   - name: billimek
     email: jeff@billimek.com
+

--- a/charts/plex/Chart.yaml
+++ b/charts/plex/Chart.yaml
@@ -13,4 +13,3 @@ sources:
 maintainers:
   - name: billimek
     email: jeff@billimek.com
-

--- a/charts/plex/README.md
+++ b/charts/plex/README.md
@@ -1,6 +1,6 @@
 # Plex Media Server helm chart
 
-This is an opinionated helm chart for Plex Media Center based on the [official container image](https://hub.docker.com/r/plexinc/pms-docker/).
+This is an opinionated helm chart for Plex Media Center based on the [linuxserver.io container image](https://hub.docker.com/r/linuxserver/plex/). This is because the [official container image](https://hub.docker.com/r/plexinc/pms-docker/) does not include arm builds.
 
 This chart is 'forked' from the excellent [munnerz/kube-plex](https://github.com/munnerz/kube-plex) repo in order to allow for more timely updates and publishing to a helm registry.  **NOTE:** This chart is not compatible as an upgrade from the `kube-plex` chart.
 

--- a/charts/plex/values.yaml
+++ b/charts/plex/values.yaml
@@ -5,8 +5,8 @@
 # The Image to use for PLEX
 
 image:
-  repository: plexinc/pms-docker
-  tag: 1.19.1.2645-ccb6eb67e
+  repository: linuxserver/plex
+  tag: 1.19.5.3112-b23ab3896-ls113
   pullPolicy: IfNotPresent
 
 #####   START  --> Official PLEX container environment variables


### PR DESCRIPTION
https://github.com/billimek/billimek-charts/issues/320

As this project largely serves home projects, a fair number of the audience may be using arm based SBC clusters (especially with there now being an 8GB Raspberry Pi).

I am aware that the Plex maintained docker images only cater to x86, however the linuxserver.io images include arm images.

While it may require significant effort to cleanly migrate, my proposal would be to do so, so as to cater to a wider audience.

While it would mean moving away from the official images, linuxserver.io has a good reputation for maintaining high quality images.

https://hub.docker.com/r/linuxserver/plex/

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
